### PR TITLE
Replace deprecated method 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/machine.lua
+++ b/machine.lua
@@ -277,7 +277,7 @@ then
 			for i = 0, anzahl-1 do
 				give[i+1]=inv:add_item("res",shape)
 			end
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				ingotstack:take_item()
 				ingotstack2:take_item()
 			end


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267